### PR TITLE
Add Claude Code plugin (P1): manifest, bundled MCP server, destructive-action guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "pyqualys",
+  "description": "Qualys vulnerability management tooling for Claude Code, built on the pyqualys API client",
+  "owner": {
+    "name": "Amit Ghadge",
+    "email": "amitg.b14@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "pyqualys",
+      "source": "./plugin",
+      "description": "Launch and triage Qualys VM scans, list host assets, and pull VMDR detections",
+      "version": "0.1.0",
+      "author": {
+        "name": "Amit Ghadge"
+      },
+      "keywords": ["qualys", "vulnerability", "vmdr", "security"]
+    }
+  ]
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "pyqualys",
+  "displayName": "Qualys VM",
+  "version": "0.1.0",
+  "description": "Launch and triage Qualys VM scans, list host assets, and pull VMDR detections",
+  "author": {
+    "name": "Amit Ghadge",
+    "email": "amitg.b14@gmail.com"
+  },
+  "homepage": "https://github.com/Amitgb14/pyqualys",
+  "repository": "https://github.com/Amitgb14/pyqualys",
+  "license": "MIT",
+  "keywords": [
+    "qualys",
+    "vulnerability",
+    "vmdr",
+    "security",
+    "scanning"
+  ],
+  "userConfig": {
+    "qualys_api_url": {
+      "type": "string",
+      "title": "Qualys API URL",
+      "description": "Your platform's API base URL. This is per-POD and getting it wrong causes confusing auth failures. Find yours under Help > About in the Qualys UI, e.g. https://qualysapi.qg2.apps.qualys.com/ for QG2 US.",
+      "default": "https://qualysapi.qualys.com/",
+      "required": true
+    },
+    "qualys_username": {
+      "type": "string",
+      "title": "Qualys username",
+      "description": "A user with API access. Prefer a dedicated account with the narrowest role that permits scan launch and read.",
+      "required": true
+    },
+    "qualys_password": {
+      "type": "string",
+      "title": "Qualys password",
+      "description": "Stored in your OS keychain, never written to settings.json.",
+      "sensitive": true,
+      "required": true
+    }
+  }
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "qualys": {
+      "command": "uvx",
+      "args": [
+        "--python", "3.12",
+        "--from", "pyqualys[mcp]==0.1.0",
+        "pyqualys-mcp"
+      ],
+      "env": {
+        "QUALYS_API_URL": "${user_config.qualys_api_url}",
+        "QUALYS_USERNAME": "${user_config.qualys_username}",
+        "QUALYS_PASSWORD": "${user_config.qualys_password}"
+      }
+    }
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,96 @@
+# Qualys VM plugin for Claude Code
+
+Wraps the [`pyqualys`](https://github.com/Amitgb14/pyqualys) MCP server so you can launch and
+triage Qualys VM scans from Claude Code without hand-wiring environment variables.
+
+## Requirements
+
+- **[`uv`](https://docs.astral.sh/uv/)** must be installed and on your `PATH`. The plugin runs the
+  server with `uvx --python 3.12`, which provisions its own interpreter. This matters because the
+  MCP Python SDK requires Python 3.10+ and many systems still ship 3.9 — `uvx` sidesteps that
+  entirely. If `uvx` is missing, the server will not start.
+- A Qualys account with API access.
+
+## Install
+
+```
+/plugin marketplace add Amitgb14/pyqualys
+/plugin install pyqualys@pyqualys
+```
+
+On enable you'll be prompted for three values:
+
+| Field | Notes |
+| :--- | :--- |
+| **Qualys API URL** | Per-POD. Find yours under **Help → About** in the Qualys UI. The default (`qualysapi.qualys.com`) is US Platform 1 — if you're on QG2, QG3, EU, etc. the default will fail to authenticate. |
+| **Qualys username** | Prefer a dedicated account with the narrowest role that permits scan launch and read. |
+| **Qualys password** | Marked `sensitive`, so it goes to your OS keychain — never to `settings.json`. |
+
+Credentials reach the server as environment variables. They are never passed as tool arguments and
+never appear in tool output.
+
+## Tools
+
+| Tool | What it does |
+| :--- | :--- |
+| `qualys_launch_vm_scan` | Launch a VM scan against IPs or asset groups |
+| `qualys_list_vm_scans` | List scans; filter by reference to check status |
+| `qualys_fetch_vm_scan_results` | Fetch results for a finished scan |
+| `qualys_manage_vm_scan` | Cancel, pause, resume or delete a scan — **guarded, see below** |
+| `qualys_list_hosts` | List host assets, with pagination |
+| `qualys_list_host_detections` | Pull VMDR detections (the vulnerability findings) |
+
+### Scan launch is asynchronous
+
+`qualys_launch_vm_scan` returns a scan *reference* immediately — not results. The scan itself can
+take hours. Poll with `qualys_list_vm_scans` filtered by that reference, then fetch once it's
+finished.
+
+Poll with backoff, not in a tight loop. Qualys signals rate and concurrency limits with **HTTP
+409**, not 429, and those limits are **per subscription** — aggressive polling can exhaust the API
+budget for your whole security team, not just your session.
+
+### Destructive actions are gated
+
+`qualys_manage_vm_scan` with `action=cancel` or `action=delete` triggers a `PreToolUse` hook that
+escalates to an explicit permission prompt. `delete` permanently removes a scan and its results;
+`cancel` stops a running scan and cannot be undone. `pause` and `resume` are reversible and pass
+through without a prompt.
+
+The guard fails safe: if it cannot parse the payload or does not recognise the action, it escalates
+rather than allowing.
+
+## Local development
+
+The plugin pins `pyqualys[mcp]==0.1.0` from PyPI. To develop against a local checkout instead, edit
+`.mcp.json` to point at your working tree:
+
+```json
+{
+  "mcpServers": {
+    "qualys": {
+      "command": "uvx",
+      "args": ["--python", "3.12", "--from", "/path/to/pyqualys[mcp]", "pyqualys-mcp"],
+      "env": {
+        "QUALYS_API_URL": "${user_config.qualys_api_url}",
+        "QUALYS_USERNAME": "${user_config.qualys_username}",
+        "QUALYS_PASSWORD": "${user_config.qualys_password}"
+      }
+    }
+  }
+}
+```
+
+Then load it without installing:
+
+```
+claude --plugin-dir ./plugin
+/reload-plugins          # after each edit
+claude plugin validate ./plugin
+```
+
+## Caveats
+
+The Qualys endpoint versions this build targets (`api/3.0` for scan list, `api/5.0` for the host
+endpoints) were derived from vendor documentation and verified against mocks, not against a live
+subscription. Confirm behaviour on a non-production subscription before relying on it.

--- a/plugin/hooks/guard-destructive.sh
+++ b/plugin/hooks/guard-destructive.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# PreToolUse guard for qualys_manage_vm_scan.
+#
+# `delete` permanently removes a scan and its results, and `cancel` cannot
+# be undone - both act on a live Qualys subscription. This escalates those
+# two actions to an explicit user prompt. `pause` and `resume` are
+# reversible and pass straight through.
+#
+# Fails SAFE: anything this script cannot confidently classify is escalated
+# rather than allowed. A guard that silently allows on error is worse than
+# no guard, because it reads as protection in review.
+#
+# Takes no credentials and interpolates no ${user_config.*} - those are
+# rejected in shell-form hook commands precisely because the value would
+# reach a shell.
+
+set -uo pipefail
+
+exec python3 -c '
+import json
+import sys
+
+DESTRUCTIVE = ("cancel", "delete")
+REVERSIBLE = ("pause", "resume")
+
+
+def escalate(reason):
+    json.dump({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }, sys.stdout)
+    sys.exit(0)
+
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    escalate("Qualys scan guard could not parse the hook payload, so it "
+             "cannot confirm this action is reversible. Escalating.")
+
+action = (payload.get("tool_input") or {}).get("action")
+
+if action in REVERSIBLE:
+    # Reversible - defer to the normal permission flow.
+    sys.exit(0)
+
+if action in DESTRUCTIVE:
+    scan_ref = (payload.get("tool_input") or {}).get("scan_ref", "unknown")
+    if action == "delete":
+        detail = ("permanently removes the scan and its results from the "
+                  "Qualys subscription. This cannot be undone.")
+    else:
+        detail = ("stops a running scan on the Qualys subscription. This "
+                  "cannot be undone, and partial results may be lost.")
+    escalate("Qualys scan guard: action=%s on %s %s Confirm before "
+             "proceeding." % (action, scan_ref, detail))
+
+escalate("Qualys scan guard does not recognise action=%r on "
+         "qualys_manage_vm_scan, so it cannot confirm the action is "
+         "reversible. Escalating." % (action,))
+'

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__plugin_pyqualys_qualys__qualys_manage_vm_scan",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/guard-destructive.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Implements **P1** from `docs/claude-plugin-proposal.md`: packages the `pyqualys` MCP server as an installable Claude Code plugin.

## What's here

| File | Purpose |
| :--- | :--- |
| `plugin/.claude-plugin/plugin.json` | Manifest with `userConfig` |
| `plugin/.mcp.json` | Bundles the server, pinned `pyqualys[mcp]==0.1.0` |
| `plugin/hooks/` | `PreToolUse` guard on destructive scan actions |
| `plugin/README.md` | Install, caveats, local-dev path |
| `.claude-plugin/marketplace.json` | Makes this repo its own marketplace |

Skills are deliberately **not** included — those are P2.

## Credentials

`userConfig` prompts for the API URL, username and password at enable time. The password is marked `sensitive`, which routes it to the **OS keychain** rather than `settings.json`. Values reach the server as env vars via `${user_config.*}` substitution; they are never tool arguments.

Note that Claude Code reads `pluginConfigs` only from user/managed settings and deliberately ignores a project's `.claude/settings.json`, so a cloned repo cannot inject credentials into the MCP config.

## Destructive-action guard

`qualys_manage_vm_scan` can `cancel` and `delete` scans on a live subscription, irreversibly. The hook escalates those two to an explicit permission prompt; `pause`/`resume` pass through.

It **fails safe** — an unparseable payload or unrecognised action escalates rather than allowing. A guard that silently allows on error is worse than no guard, since it reads as protection in review.

The matcher uses the scoped name `mcp__plugin_pyqualys_qualys__qualys_manage_vm_scan`. A matcher written against the bare `qualys` server key would look correct and never fire.

## Testing

- `claude plugin validate ./plugin --strict` — passes clean
- `claude plugin validate .` (marketplace) — passes clean
- Guard exercised over all 7 payload cases: `delete`, `cancel` → `ask`; `pause`, `resume` → pass through; unknown action, missing `tool_input`, malformed JSON → `ask`

## Blocker before this is usable

**`pyqualys` 0.1.0 is not on PyPI yet** (latest is 0.0.4), so the pinned install cannot resolve and the server will not start:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of pyqualys[mcp]==0.1.0 ...
```

P0's `twine upload` step closes this. Until then, `plugin/README.md` documents pointing `.mcp.json` at a local checkout.

Not merging — leaving open for review.

Generated with [Claude Code](https://claude.com/claude-code)