### PR TITLE
Surface scan sub_state in the MCP summary (0.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,21 @@ Not changed on purpose: `asset_ips.py` still targets the legacy V1
 `msp/asset_ip.php` endpoints and `Reports` stays on `api/2.0/fo/report/`.
 
 
+Changes in 0.1.1
+-----------
+
+`qualys_list_vm_scans` now returns `sub_state` alongside `state`. Qualys
+qualifies a scan state with `STATUS/SUB_STATE`, and the MCP summary was
+dropping it. The case that matters is `state="Finished"` with
+`sub_state="No_Host"`: the scan ran to completion without reaching any
+host, so empty results mean the target was wrong, not that the hosts are
+healthy. Without the sub-state those two outcomes are indistinguishable.
+
+Library-level behaviour is unchanged - `scan_list()` always returned the
+full decoded response including `SUB_STATE`. Only the MCP summary was
+lossy.
+
+
 MCP server
 -----------
 

--- a/pyqualys/__init__.py
+++ b/pyqualys/__init__.py
@@ -2,7 +2,7 @@
 import logging
 from .utils.connect import QualysAPI
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # basicConfig defaults to stderr, so this is safe for the stdio MCP
 # transport. pyqualys.mcp.server still calls basicConfig first, because

--- a/pyqualys/mcp/server.py
+++ b/pyqualys/mcp/server.py
@@ -260,6 +260,11 @@ class ScanSummary(BaseModel):
     scan_ref: Optional[str] = Field(None, description="Scan reference.")
     title: Optional[str] = None
     state: Optional[str] = Field(None, description="Running, Finished, ...")
+    sub_state: Optional[str] = Field(
+        None,
+        description=("Qualifies state. No_Host on a Finished scan means "
+                     "the scan completed without reaching any host, which "
+                     "is a targeting failure, not a clean result."))
     launch_datetime: Optional[str] = None
     target: Optional[str] = None
     processed: Optional[str] = None
@@ -425,6 +430,11 @@ async def qualys_list_vm_scans(
     States are Running, Paused, Canceled, Finished, Error, Queued and
     Loading.
 
+    Check sub_state before reporting a finished scan as clean:
+    state="Finished" with sub_state="No_Host" means the scan completed
+    without reaching any host, so empty results mean the target was
+    wrong, not that the hosts are healthy.
+
     IMPORTANT: with no launched_after_datetime filter Qualys returns
     only scans from the past 30 days.
 
@@ -455,6 +465,7 @@ async def qualys_list_vm_scans(
             scan_ref=_text(_dig(scan, "REF")),
             title=_text(_dig(scan, "TITLE")),
             state=_text(_dig(scan, "STATUS", "STATE")),
+            sub_state=_text(_dig(scan, "STATUS", "SUB_STATE")),
             launch_datetime=_text(_dig(scan, "LAUNCH_DATETIME")),
             target=_text(_dig(scan, "TARGET")),
             processed=_text(_dig(scan, "PROCESSED"))))

--- a/pyqualys/tests/contract_tests/test_mcp_contract.py
+++ b/pyqualys/tests/contract_tests/test_mcp_contract.py
@@ -105,7 +105,28 @@ class TestScanListContract(ContractToolTestCase):
         self.assertEqual(scan.launch_datetime, "2024-12-30T07:32:52Z")
         self.assertEqual(scan.processed, "1")
 
-    async def test_02_cdata_values_arrive_clean(self):
+    async def test_02_sub_state_qualifies_the_state(self):
+        # The vendor sample is Finished with SUB_STATE No_Host: the scan
+        # ran to completion without reaching a host. Reporting only
+        # state="Finished" with no findings is indistinguishable from a
+        # genuinely clean scan, so the sub-state has to survive into the
+        # summary rather than being dropped in the mapping.
+        _, result = await self.invoke(server.qualys_list_vm_scans,
+                                      FakeResponse(vendor.SCAN_LIST_OUTPUT))
+        scan = result.scans[0]
+        self.assertEqual(scan.state, "Finished")
+        self.assertEqual(scan.sub_state, "No_Host")
+
+    async def test_03_absent_sub_state_is_none_not_an_error(self):
+        # Most scans carry STATUS/STATE with no SUB_STATE sibling.
+        body = vendor.SCAN_LIST_OUTPUT.replace(
+            "<SUB_STATE>No_Host</SUB_STATE>", "")
+        _, result = await self.invoke(server.qualys_list_vm_scans,
+                                      FakeResponse(body))
+        self.assertEqual(result.scans[0].state, "Finished")
+        self.assertIsNone(result.scans[0].sub_state)
+
+    async def test_04_cdata_values_arrive_clean(self):
         # TITLE and TARGET are printed as indented CDATA in the guide.
         _, result = await self.invoke(server.qualys_list_vm_scans,
                                       FakeResponse(vendor.SCAN_LIST_OUTPUT))
@@ -114,7 +135,7 @@ class TestScanListContract(ContractToolTestCase):
         self.assertNotIn("\n", scan.target or "")
         self.assertTrue((scan.target or "").startswith("65188eb1"))
 
-    async def test_03_single_scan_is_not_flattened_into_characters(self):
+    async def test_05_single_scan_is_not_flattened_into_characters(self):
         # One <SCAN> collapses to a dict rather than a list of dicts.
         # Iterating that dict directly yields its keys, and every scan
         # summary comes back empty.
@@ -123,7 +144,7 @@ class TestScanListContract(ContractToolTestCase):
         self.assertEqual(len(result.scans), 1)
         self.assertIsNotNone(result.scans[0].scan_ref)
 
-    async def test_04_the_30_day_default_is_disclosed(self):
+    async def test_06_the_30_day_default_is_disclosed(self):
         _, result = await self.invoke(server.qualys_list_vm_scans,
                                       FakeResponse(vendor.SCAN_LIST_OUTPUT))
         self.assertIn("30 days", result.note or "")


### PR DESCRIPTION
## The bug

Qualys qualifies a scan state with `STATUS/SUB_STATE`, and `ScanSummary` was dropping it.

The case that matters:

| Qualys returns | MCP summary returned | 
|---|---|
| `state=Finished`, `sub_state=No_Host` | `state=Finished` |
| `state=Finished` (genuinely clean) | `state=Finished` |

`No_Host` means the scan ran to completion **without reaching any host**. An agent polling a mis-targeted scan saw `Finished`, fetched no findings, and had no way to distinguish "nothing is wrong" from "nothing was scanned" — so it reports an all-clear on a scan that never touched the target.

The data was always present: `scan_list()` returns the full decoded response, and the contract tests already assert `SUB_STATE` is in the vendor's documented body. Only the MCP summary was lossy.

## The fix

- `ScanSummary.sub_state` added and populated from `STATUS/SUB_STATE`
- The distinction is stated in the `qualys_list_vm_scans` docstring, which is what the model reads before deciding what a finished scan means
- Version → `0.1.1`, README section describing the change

No library-level behaviour changed.

## Tests

Two, both in `test_mcp_contract.py` against the vendor's documented body:

- the sample (`Finished` / `No_Host`) surfaces both fields
- a scan with no `SUB_STATE` sibling yields `None` rather than erroring — most scans have no sub-state

## Verification

- `206 passed, 30 skipped` (was 204/30)
- `pycodestyle pyqualys/mcp/` clean; no new `flake8` findings
- Built sdist + wheel from a pristine tree: **`twine check` PASSED** on both
- Installed **from the sdist** (`--no-binary`) into a fresh venv to confirm it is still self-sufficient, started the server, and ran an MCP handshake against it — `ScanSummary` in the published `outputSchema` now reads `[scan_ref, title, state, sub_state, launch_datetime, target, processed]`, and the tool description carries the `No_Host` warning

```
sha256  3a5d6f85…  pyqualys-0.1.1-py3-none-any.whl
sha256  935ae91f…  pyqualys-0.1.1.tar.gz
```

## Release sequence

Artifacts are built and checked but **not uploaded** — that needs your PyPI token. After merging:

```
git tag v0.1.1 && git push origin v0.1.1
uvx twine upload dist/*
```

Then PR #5 (the skills) should bump its pin from `pyqualys[mcp]==0.1.0` to `==0.1.1`, and `/pyqualys:scan` can use `sub_state` directly instead of the workaround it currently carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
