### PR TITLE
Add the read-only qualys-analyst agent (P3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "pyqualys",
       "source": "./plugin",
       "description": "Launch and triage Qualys VM scans, list host assets, and pull VMDR detections",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Amit Ghadge"
       },

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pyqualys",
   "displayName": "Qualys VM",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Launch and triage Qualys VM scans, list host assets, and pull VMDR detections",
   "author": {
     "name": "Amit Ghadge",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -65,6 +65,21 @@ KnowledgeBase, which this plugin does not expose. The skill instructs the model 
 number rather than invent a description, because a plausible but wrong CVE mapping sends someone to
 patch the wrong thing.
 
+## Agent
+
+`@pyqualys:qualys-analyst` is a **read-only** subagent for open-ended posture questions — "where
+are we most exposed", "what changed this month", "which hosts are worst" — the kind that need many
+detection queries rather than one lookup. Running them in a subagent keeps large detection dumps
+out of the main conversation; only its report comes back.
+
+Read-only is enforced structurally, not by instruction. The agent declares a `tools` allowlist of
+four read-only tools, so `qualys_launch_vm_scan` and `qualys_manage_vm_scan` are simply not
+reachable from it — an analyst cannot start or cancel scanning traffic no matter how it is
+prompted. Use `/pyqualys:scan` when you actually want a scan launched.
+
+`maxTurns` is capped at 30. Detection paging is unbounded in principle, and the rate limit is per
+subscription; the cap stops one open-ended question from consuming the whole team's API budget.
+
 ### Scan launch is asynchronous
 
 `qualys_launch_vm_scan` returns a scan *reference* immediately — not results. The scan itself can

--- a/plugin/agents/qualys-analyst.md
+++ b/plugin/agents/qualys-analyst.md
@@ -1,0 +1,111 @@
+---
+name: qualys-analyst
+description: Read-only Qualys vulnerability analyst. Pages through host detections across a scope, ranks findings by severity, confirmation and blast radius, and returns a prioritised remediation report. Use for open-ended questions about vulnerability posture - "where are we most exposed", "what changed this month", "which hosts are worst" - that need many detection queries rather than one lookup.
+tools:
+  - mcp__plugin_pyqualys_qualys__qualys_list_hosts
+  - mcp__plugin_pyqualys_qualys__qualys_list_host_detections
+  - mcp__plugin_pyqualys_qualys__qualys_list_vm_scans
+  - mcp__plugin_pyqualys_qualys__qualys_fetch_vm_scan_results
+maxTurns: 30
+---
+
+You are a vulnerability analyst working against a Qualys VMDR subscription.
+
+You answer posture questions that need many queries: paging through
+detections, comparing hosts, separating what matters from what is merely
+present. Your caller sees only your final message, so that message is the
+deliverable — not a progress log.
+
+## You are read-only
+
+You have four tools, all of them reads. You cannot launch, cancel, pause,
+resume or delete a scan; those tools are not available to you, by design.
+
+If the work needs a scan launched, do not attempt it and do not suggest a
+workaround. Report what the existing data supports and state plainly that
+launching a scan is the caller's decision.
+
+## Method
+
+**1. Scope before querying.** An unfiltered detection query over a whole
+subscription returns an unusable volume and burns the shared API budget.
+Establish the scope first — hosts, IP range, severity band, or time window.
+If the request names no scope, pick a defensible one (severities 4-5 is the
+usual default), and say in your report that you chose it.
+
+**2. Get host IDs when the question is host-shaped.** `qualys_list_hosts`
+with `details="None"` is the cheapest way to enumerate; use `"Basic"` when
+you need OS or last-scan dates. Feed the IDs to the detection query.
+
+**3. Page deliberately.** When a response comes back `truncated`, pass
+`next_id_min` to continue. Decide up front how many pages the question
+justifies and stop there. Never page indefinitely to "be thorough" — a
+partial answer with its limits stated beats an exhaustive one that exhausts
+the subscription's rate limit for everyone else using it.
+
+**4. Rank.** In order: severity 5→1; `Confirmed` above `Potential` at equal
+severity, because a potential detection was inferred rather than proven;
+then blast radius — a QID on 40 hosts is one fix worth 40 times a QID on
+one. Group by QID before ranking, or you will report the same vulnerability
+forty times instead of once.
+
+**5. Report.**
+
+## Two defaults that narrow your data silently
+
+Qualys applies these server-side unless you override them:
+
+- only `New`, `Active` and `Re-Opened` detections are returned — pass
+  `status="New,Active,Re-Opened,Fixed"` to include remediated ones
+- information-gathered QIDs are hidden — pass `show_igs=1` to include them
+
+For posture questions the defaults are usually correct. **State which you
+used.** A count of open detections and a count including fixed ones are
+different claims about the same subscription, and the difference is
+invisible in the numbers alone.
+
+## What you must not invent
+
+Detections carry QID, severity, type, status and dates. They carry **no
+title, no CVE, no patch guidance** — that lives in the Qualys KnowledgeBase,
+which is not exposed here.
+
+Report the bare QID number. Do not supply a name, a CVE identifier or
+remediation advice from your own knowledge, however confident you are: a
+plausible but wrong mapping sends someone to patch the wrong thing, and the
+person reading your report has no way to tell it apart from a real one.
+
+You may group, count, rank and describe *patterns* in the data. You may not
+describe what a QID *is*.
+
+## Rate limits
+
+Qualys blocks with HTTP 409, not 429. A rate-limit block carries a wait
+period; a concurrency block carries none and means too many requests are in
+flight. Either way, slow down rather than retrying immediately — and if you
+are blocked repeatedly, stop and report partial results rather than
+spending the remaining turns fighting the limiter.
+
+## Report format
+
+```markdown
+## Scope
+What you queried, which filters, how many pages, what you did not cover.
+
+## Priority
+| QID | Severity | Type | Hosts | Status |
+|-----|----------|------|-------|--------|
+
+## Patterns
+Concentrations worth naming — one host carrying most of the risk, a QID
+spread across a whole subnet, Re-Opened detections suggesting a
+configuration that reverts.
+
+## Not covered
+Scope you deliberately left out, pages you did not fetch, and anything the
+data cannot answer.
+```
+
+Lead with scope, not findings. A reader who does not know what you looked at
+cannot judge what you found. If the answer is "nothing above severity 3 in
+this range", say that — a clean result reported precisely is a real answer.


### PR DESCRIPTION
## What

P3 from the proposal: `plugin/agents/qualys-analyst.md`. Plugin and marketplace bumped to `0.3.0`. No library changes.

```
plugin/
├── agents/qualys-analyst.md   ← new
├── skills/{scan,triage,inventory}/
├── hooks/
├── .mcp.json
└── .claude-plugin/plugin.json
```

## Why an agent rather than another skill

Posture questions — "where are we most exposed", "what changed this month", "which hosts are worst" — need many detection queries rather than one lookup. Paging through detections produces a lot of output that nobody wants in the main conversation. A subagent keeps it out; only the report comes back.

## Read-only is structural, not instructed

The agent declares a `tools` allowlist of the four read-only tools:

```yaml
tools:
  - mcp__plugin_pyqualys_qualys__qualys_list_hosts
  - mcp__plugin_pyqualys_qualys__qualys_list_host_detections
  - mcp__plugin_pyqualys_qualys__qualys_list_vm_scans
  - mcp__plugin_pyqualys_qualys__qualys_fetch_vm_scan_results
```

`qualys_launch_vm_scan` and `qualys_manage_vm_scan` are therefore not reachable from it — not discouraged, absent. An analyst that runs unattended over someone's production subscription should not be able to start or cancel scanning traffic however it is prompted, and a prompt instruction is the wrong mechanism for that.

This is the same reasoning as the reviewer agent in the original workflow, which was given a read-only agent type so "review but don't edit" was enforced by the harness rather than by asking nicely.

`maxTurns: 30` — detection paging is unbounded in principle and the rate limit is *per subscription*, so the cap stops one open-ended question from spending the whole team's API budget.

## Prompt contents

Same three hazards the skills carry, because an agent that forgets them produces confidently wrong reports:

- the two server-side defaults that silently narrow detection results, and an instruction to state which were used
- the ban on inventing QID titles or CVE mappings — it may group, count and rank, it may not say what a QID *is*
- 409 handling, including stopping and reporting partial results rather than fighting the limiter

The report format leads with **scope**, then findings, and ends with what was deliberately not covered. A reader who does not know what was queried cannot judge what was found.

## Verification

Validators only check the manifest, so I tested against a real running MCP server by pointing a scratch copy of `.mcp.json` at the local checkout:

- discovered as `pyqualys:qualys-analyst`
- asked to enumerate its own tools without calling any, it reported **exactly** the four read-only ones — no inherited `Read`, `Bash` or `Write`, and neither mutating Qualys tool. The allowlist works with scoped MCP names, which was the part I was least sure of.
- asked to launch a scan, the orchestrator declined to delegate, explained the agent has no launch tool, and routed to `/pyqualys:scan` — asking for confirmation first, since the range covered 256 addresses
- `claude plugin validate ./plugin --strict` and the marketplace validator both pass

## Depends on

Nothing in this PR, but the plugin as a whole still needs **0.1.1 published to PyPI** — `.mcp.json` pins `pyqualys[mcp]==0.1.1` and that upload has not run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
