### PR TITLE
Restructure the README changelog and document the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,31 @@ service = VulnerabilityService(qualys.session, api="api/2.0/",
 ```
 
 
-Breaking changes in 0.1.0
+Changelog
 -----------
+
+Newest first. The Claude Code plugin under `plugin/` versions separately -
+its own history is at the end of this section.
+
+### 0.1.1
+
+`qualys_list_vm_scans` now returns `sub_state` alongside `state`. Qualys
+qualifies a scan state with `STATUS/SUB_STATE`, and the MCP summary was
+dropping it. The case that matters is `state="Finished"` with
+`sub_state="No_Host"`: the scan ran to completion without reaching any
+host, so empty results mean the target was wrong, not that the hosts are
+healthy. Without the sub-state those two outcomes are indistinguishable,
+and an agent polling a mis-targeted scan reports an all-clear.
+
+Library-level behaviour is unchanged - `scan_list()` always returned the
+full decoded response including `SUB_STATE`. Only the MCP summary was
+lossy.
+
+Also adds `pyqualys/tests/contract_tests/`, which parses response bodies
+and HTTP headers transcribed from the Qualys API user guide rather than
+from fixtures this project wrote. See the Tests section.
+
+### 0.1.0 - breaking changes
 
 1. **TLS verification is now on by default.** `APISession.verify_ssl`
    flipped from `False` to `True`; every request this library made used to
@@ -200,20 +223,19 @@ Breaking changes in 0.1.0
 Not changed on purpose: `asset_ips.py` still targets the legacy V1
 `msp/asset_ip.php` endpoints and `Reports` stays on `api/2.0/fo/report/`.
 
+### Claude Code plugin
 
-Changes in 0.1.1
------------
+`plugin/` packages the MCP server below as a [Claude Code
+plugin](https://code.claude.com/docs/en/plugins), so credentials are
+prompted once and stored in the OS keychain instead of being wired into a
+config file by hand. It is versioned independently of the library and
+pins an exact library version. See `plugin/README.md`.
 
-`qualys_list_vm_scans` now returns `sub_state` alongside `state`. Qualys
-qualifies a scan state with `STATUS/SUB_STATE`, and the MCP summary was
-dropping it. The case that matters is `state="Finished"` with
-`sub_state="No_Host"`: the scan ran to completion without reaching any
-host, so empty results mean the target was wrong, not that the hosts are
-healthy. Without the sub-state those two outcomes are indistinguishable.
-
-Library-level behaviour is unchanged - `scan_list()` always returned the
-full decoded response including `SUB_STATE`. Only the MCP summary was
-lossy.
+| Plugin | Pins | Adds |
+| --- | --- | --- |
+| 0.3.0 | `pyqualys[mcp]==0.1.1` | `qualys-analyst`, a read-only subagent for posture questions. Its `tools` allowlist covers only the four read-only tools, so it cannot launch or manage scans however it is prompted. |
+| 0.2.0 | `pyqualys[mcp]==0.1.1` | Three skills: `/pyqualys:scan`, `/pyqualys:triage`, `/pyqualys:inventory`. |
+| 0.1.0 | `pyqualys[mcp]==0.1.0` | Manifest, `userConfig` credential prompts, the bundled MCP server, and a `PreToolUse` guard that escalates `cancel` and `delete` to an explicit permission prompt. |
 
 
 MCP server


### PR DESCRIPTION
## What

One `Changelog` section in `README.md`, newest first, plus the plugin's version history.

Before:

```
Breaking changes in 0.1.0     ← older release printed first
Changes in 0.1.1
```

After:

```
Changelog
├── 0.1.1
├── 0.1.0 - breaking changes  ← all nine entries intact
└── Claude Code plugin        ← was not mentioned in this README at all
```

## Why the plugin table exists

| Plugin | Pins | Adds |
| --- | --- | --- |
| 0.3.0 | `pyqualys[mcp]==0.1.1` | `qualys-analyst` read-only subagent |
| 0.2.0 | `pyqualys[mcp]==0.1.1` | three skills |
| 0.1.0 | `pyqualys[mcp]==0.1.0` | manifest, credentials, MCP server, destructive-action guard |

The pins are the part worth writing down. The plugin **fails to start** rather than degrading when its pinned version is absent from PyPI — we hit exactly that twice during development, and once more for a few minutes after the 0.1.1 upload while the `/simple/` index caught up. Which library version a plugin release needs is operational information, not trivia.

Version/pin pairs verified against git history rather than from memory:

```
625cf1f  plugin=0.1.0  pin==0.1.0
7a9c660  plugin=0.2.0  pin==0.1.0
67fff78  plugin=0.2.0  pin==0.1.1   ← final state of 0.2.0
101bdf4  plugin=0.3.0  pin==0.1.1
```

The table lists each version's final state, which is why 0.2.0 shows `==0.1.1`.

## Also

The contract tests shipped in 0.1.1 but were missing from the changelog — now recorded there, pointing at the existing Tests section.

## Scope

Documentation only. No content removed; the nine 0.1.0 breaking-change entries are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
